### PR TITLE
Add resend-confirmation endpoint

### DIFF
--- a/src/routes/auth/index.ts
+++ b/src/routes/auth/index.ts
@@ -16,6 +16,7 @@ import activateAccount from './activate'
 import deleteAccount from './delete'
 import magicLink from './magic-link'
 import smsMfa from './mfa/sms'
+import resendConfirmation from './resend-confirmation'
 
 const router = Router()
 
@@ -36,6 +37,7 @@ router.use('/mfa/sms', smsMfa)
 router.use('/change-email', changeEmail)
 router.get('/activate', activateAccount)
 router.post('/delete', deleteAccount)
+router.post('/resend-confirmation', resendConfirmation)
 router
   .post('/login', loginAccount)
   .post('/logout', logout)

--- a/src/routes/auth/resend-confirmation.ts
+++ b/src/routes/auth/resend-confirmation.ts
@@ -1,0 +1,74 @@
+import { Request, Response } from 'express'
+import { v4 as uuidv4 } from 'uuid'
+
+import { asyncWrapper, selectAccount, updateAccountTicket } from '@shared/helpers'
+import { APPLICATION, REGISTRATION } from '@shared/config'
+import { emailClient } from '@shared/email'
+import { UserData } from '@shared/types'
+
+/**
+ * Sends the activate account email with a new ticket
+ */
+async function resendConfirmation(req: Request, res: Response): Promise<unknown> {
+  if (REGISTRATION.AUTO_ACTIVATE_NEW_USERS) {
+    return res.boom.badImplementation(`Accounts are automatically activated.`)
+  }
+
+  const body = req.body
+
+  try {
+    const account = await selectAccount(body)
+
+    if (!account) {
+      return res.boom.badRequest('Account does not exist.')
+    } else if (account.active) {
+      return res.boom.badRequest('Account already activated.')
+    }
+
+    const ticket = uuidv4()
+    const now = new Date()
+    const ticket_expires_at = new Date()
+    ticket_expires_at.setTime(now.getTime() + 60 * 60 * 1000) // active for 60 minutes
+
+    const user: UserData = {
+      id: account.user.id,
+      display_name: account.user.display_name,
+      email: account.email,
+      avatar_url: account.user.avatar_url
+    }
+
+    if (!APPLICATION.EMAILS_ENABLE) {
+      return res.boom.badImplementation('SMTP settings unavailable')
+    }
+
+    // use display name from `user_data` if available
+    const display_name = user.display_name || user.email
+
+    await updateAccountTicket(account.id, ticket, ticket_expires_at)
+
+    await emailClient.send({
+      template: 'activate-account',
+      message: {
+        to: user.email,
+        headers: {
+          'x-ticket': {
+            prepared: true,
+            value: ticket
+          }
+        }
+      },
+      locals: {
+        display_name,
+        ticket,
+        url: APPLICATION.SERVER_URL
+      }
+    })
+
+    return res.status(204).send()
+  } catch (err) {
+    console.error(err)
+    return res.boom.badRequest("Failed to resend confirmation.")
+  }
+}
+
+export default asyncWrapper(resendConfirmation)

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -1,6 +1,7 @@
 import { COOKIES, REGISTRATION } from './config'
 import { NextFunction, Response } from 'express'
 import {
+  mutateAccountTicket,
   rotateTicket as rotateTicketQuery,
   selectAccountByEmail as selectAccountByEmailQuery,
   selectAccountByTicket as selectAccountByTicketQuery,
@@ -114,6 +115,18 @@ export const rotateTicket = async (ticket: string): Promise<string> => {
     new_ticket
   })
   return new_ticket
+}
+
+export const updateAccountTicket = async (id: string, ticket: string, ticket_expires_at: Date) => {
+  const res = await request<{
+    ticket: string
+    user: { display_name: string }
+  }>(mutateAccountTicket, {
+    id,
+    ticket,
+    ticket_expires_at
+  })
+  return res
 }
 
 export const getPermissionVariablesFromCookie = (req: RequestExtended): PermissionVariables => {

--- a/src/shared/queries.ts
+++ b/src/shared/queries.ts
@@ -40,6 +40,20 @@ export const insertAccount = gql`
   ${accountFragment}
 `
 
+export const mutateAccountTicket = gql`
+  mutation($id: uuid!, $ticket: uuid!, $ticket_expires_at: timestamptz!) {
+    update_auth_accounts_by_pk(
+      pk_columns: { id: $id }
+      _set: { ticket: $ticket, ticket_expires_at: $ticket_expires_at }
+    ) {
+      ticket
+      user {
+        display_name
+      }
+    }
+  }
+`
+
 export const insertAccountProviderToUser = gql`
   mutation($account_provider: auth_account_providers_insert_input!, $account_id: uuid!) {
     insert_auth_account_providers_one(object: $account_provider) {


### PR DESCRIPTION
For https://app.theask.com/cards/175

- Add endpoint for user's to resend the account activation email 
- Based off of https://github.com/nhost/hasura-backend-plus/pull/524/files).
- Accepts an email or ticket.