### PR TITLE
fix: use Spotify profile username instead of display name

### DIFF
--- a/src/routes/auth/providers/utils.ts
+++ b/src/routes/auth/providers/utils.ts
@@ -89,7 +89,7 @@ const manageProviderStrategy = (
     // noop continue to register user
   }
 
-  let username = profile.username
+  let username = profile.username ? profile.username.trim().toLowerCase() : undefined
 
   const generateRandomSequence = () => {
     return (Math.floor(Math.random() * 10000) + 10000).toString().substring(1)

--- a/src/routes/auth/providers/utils.ts
+++ b/src/routes/auth/providers/utils.ts
@@ -89,22 +89,26 @@ const manageProviderStrategy = (
     // noop continue to register user
   }
 
-  let username: string = encodeURI(display_name.trim().toLowerCase())
+  let username = profile.username
 
-  const usernameAlreadyTaken: boolean = await request<QueryUserData>(selectUserByUsername, {
-    username: display_name
-  }).then((res) => !!res.users.length)
+  const generateRandomSequence = () => {
+    return (Math.floor(Math.random() * 10000) + 10000).toString().substring(1)
+  }
 
-  if (usernameAlreadyTaken) {
-    const generateRandomSequence = () => {
-      return (Math.floor(Math.random() * 10000) + 10000).toString().substring(1)
+  if (username) {
+    const usernameAlreadyTaken: boolean = await request<QueryUserData>(selectUserByUsername, {
+      username
+    }).then((res) => !!res.users.length)
+
+    if (usernameAlreadyTaken) {
+      const appendRandomSequence = (input: string) => {
+        return input + generateRandomSequence()
+      }
+
+      username = appendRandomSequence(display_name)
     }
-
-    const appendRandomSequence = (input: string) => {
-      return input + generateRandomSequence()
-    }
-
-    username = appendRandomSequence(display_name)
+  } else {
+    username = generateRandomSequence() + generateRandomSequence() + generateRandomSequence()
   }
 
   // register user, account, account_provider


### PR DESCRIPTION
For https://app.theask.com/cards/262

Switching from using the Spotify display name to the Spotify username value when signing up the user.

- It's lowercase
- It doesn't have spaces
- It's unique to Spotify's database
- It's built with URLs in mind

If a username isn't found (through Spotify I think it's impossible not to have a username), but just in case I generated a 12 digit number as a username.